### PR TITLE
Improve aspects of the timeline implementation

### DIFF
--- a/src/totem-timeline/console.js
+++ b/src/totem-timeline/console.js
@@ -1,0 +1,127 @@
+import { observeEvents } from "./events";
+
+let subscription;
+
+export default {
+  enable(options = {}) {
+    if(subscription) {
+      subscription.unsubscribe();
+    }
+
+    subscription = subscribe(options);
+  },
+  disable() {
+    if(subscription) {
+      subscription.unsubscribe();
+      subscription = null;
+    }
+  }
+};
+
+function subscribe(options) {
+  let { filter, write, writeStopped } = buildObservation(options);
+
+  return observeEvents().subscribe(e => {
+    if(e.$type === "timeline:flowStopped") {
+      writeStopped(e);
+    }
+    else {
+      if(filter(e)) {
+        write(e);
+      }
+    }
+  });
+}
+
+function buildObservation({ level = "", filter, write, includeMetadata }) {
+  return {
+    filter: buildFilter(),
+    write: buildWrite(),
+    writeStopped
+  };
+
+  function buildFilter() {
+    let condition = buildCondition(filter, "every");
+
+    if(condition) {
+      return condition;
+    }
+
+    let include = filter && buildCondition(filter.include, "some");
+    let exclude = filter && buildCondition(filter.exclude, "some");
+
+    if(include && exclude) {
+      return e => include(e) && !exclude(e);
+    }
+    else if(include) {
+      return include;
+    }
+    else if(exclude) {
+      return e => !exclude(e);
+    }
+    else {
+      return () => true;
+    }
+  }
+
+  function buildCondition(value, arrayMethod) {
+    if(typeof value === "function") {
+      return value;
+    }
+    else if(typeof value === "string") {
+      return e => e.$type === value;
+    }
+    else if(value instanceof RegExp) {
+      return e => value.test(e.$type);
+    }
+    else if(Array.isArray(value)) {
+      let conditions = value.map(item => buildCondition(item, "every"));
+
+      return e => conditions[arrayMethod](condition => condition(e));
+    }
+    else {
+      return null;
+    }
+  }
+
+  function buildWrite() {
+    if(write) {
+      return e => write(e, level);
+    }
+
+    let method = selectMethod();
+
+    return e => method(...getDetails(e));
+  }
+
+  function writeStopped(e) {
+    let { $position, type, id, error, cause } = e;
+
+    let flow = id ? `${type}/${id}` : type;
+
+    console.error(`[${$position}] Flow "${flow}" stopped: ${error.stack}\n\nCaused by:`, ...getDetails(cause));
+  }
+
+  function selectMethod() {
+    switch(level) {
+      case "error": return console.error;
+      case "debug": return console.debug;
+      case "info": return console.info;
+      case "warn": return console.warn;
+      default: return console.log;
+    }
+  }
+
+  function getDetails(e) {
+    let { $position, $type, ...details } = e;
+
+    if(!includeMetadata) {
+      delete details.$cause;
+      delete details.$topic;
+      delete details.$when;
+      delete details.$whenOccurs;
+    }
+
+    return [`[${$position}]${e.$whenOccurs ? "@" : ""} ${$type}`, details];
+  }
+}

--- a/src/totem-timeline/index.js
+++ b/src/totem-timeline/index.js
@@ -1,13 +1,15 @@
-import http from "./http";
+import console from "./console";
 import { appendEvent, scheduleEvent } from "./events";
+import http from "./http";
 import topic from "./topics";
 import query from "./queries";
-import webQuery from "./web-queries";
+import webQuery from "./webQueries";
 
 export default {
+  console,
+  append: (type, data) => appendEvent(null, null, type, data),
+  schedule: (whenOccurs, type, data) => scheduleEvent(null, null, whenOccurs, type, data),
   http,
-  append: (type, data) => appendEvent(null, type, data),
-  schedule: (whenOccurs, type, data) => scheduleEvent(null, whenOccurs, type, data),
   topic,
   query,
   webQuery

--- a/src/totem-timeline/webQueries.js
+++ b/src/totem-timeline/webQueries.js
@@ -5,7 +5,21 @@ export default function webQuery(loadedEventType, url, options) {
   let type = new WebQueryType(loadedEventType, url, options);
 
   return {
-    bind: (args, notify) => type.bind(args, notify)
+    getDefaultData() {
+      return {
+        loading: false,
+        loaded: false,
+        loadError: null,
+        subscribing: false,
+        subscribed: false,
+        subscribeError: null,
+        etag: null,
+        data: null
+      };
+    },
+    bind(args, notify) {
+      return type.bind(args, notify);
+    }
   };
 }
 
@@ -33,7 +47,7 @@ class WebQueryType {
   }
 
   appendLoadedEvent(data) {
-    appendEvent(null, this.loadedEventType, data);
+    appendEvent(null, null, this.loadedEventType, data);
   }
 
   getEndpoint(args) {
@@ -213,7 +227,7 @@ class WebQueryClientState {
   subscribed = false;
   subscribeError = null;
   etag = null;
-  data = {};
+  data = null;
 
   constructor(binding) {
     this.binding = binding;
@@ -248,7 +262,7 @@ class WebQueryClientState {
     this.loaded = false;
     this.loadError = new Error("Query not found");
     this.etag = WebQueryETag.tryFromHeader(response);
-    this.data = {};
+    this.data = null;
 
     this.updateBinding();
   }
@@ -258,7 +272,7 @@ class WebQueryClientState {
     this.loaded = false;
     this.loadError = error;
     this.etag = null;
-    this.data = {};
+    this.data = null;
 
     this.updateBinding();
   }


### PR DESCRIPTION
- Add console API
- Declare topics and queries with syntax similar to Vue's options
- Fix issues in handling of multi-instance topics and queries
- Add explicit support for the "given" phase of topic lifetimes
- Add support for observing scheduled events
- Change the Vue query binding approach to mixins instead of higher-order components